### PR TITLE
RSDEV-444: Upgrade zenodo-java-client to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]
+- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Upgrade to rspace-parent 3.0.0
+
 ## [0.2.2]
 - Adding equals and ashcode on ZenodoSubmission
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [1.0.0]
-- Spring 6 / Hibernate 6 / Jakarta migration (RSDEV-444)
+- Spring 6 / Jakarta migration (RSDEV-444)
 - Upgrade to rspace-parent 3.0.0
 
 ## [0.2.2]

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>3.0.0</version>
+        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
     </parent>
 
     <repositories>
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>zenodo-java-client</artifactId>
-    <version>0.2.1</version>
+    <version>1.0.0</version>
     <parent>
         <groupId>com.github.rspace-os</groupId>
         <artifactId>rspace-parent</artifactId>
-        <version>2.1.3</version>
+        <version>3.0.0</version>
     </parent>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Upgrade zenodo-java-client to 1.0.0 for Spring 6 / Jakarta migration (RSDEV-444).

Pom-only parent bump; no source changes required.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
